### PR TITLE
feat: integrate pro blocks navigation and footer

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
-import { Header } from "@/components/header";
+import { Header, Footer } from "@/components";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -37,6 +37,7 @@ export default function RootLayout({
         >
           <Header />
           {children}
+          <Footer />
         </ThemeProvider>
       </body>
     </html>

--- a/src/app/medium-of-exchange/page.tsx
+++ b/src/app/medium-of-exchange/page.tsx
@@ -1,0 +1,10 @@
+import { ProRichText4 } from "@/components/problocks/rich-text-section-4";
+
+export default function MediumOfExchangePage() {
+  return (
+    <ProRichText4
+      title="Medium of Exchange"
+      content="## Placeholder\n\nDetails coming soon."
+    />
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,10 @@
-import Image from "next/image";
+import { ProRichText1 } from "@/components/problocks/rich-text-section-1";
 
 export default function Home() {
   return (
-    <div className="font-sans grid grid-rows-[1fr_20px] items-center justify-items-center min-h-[calc(100vh-3.5rem)] p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-1 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-2 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+    <ProRichText1
+      title="Manifesto"
+      content="## Placeholder\n\nContent coming soon."
+    />
   );
 }

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { ProNavbar } from "@/components/problocks/navbar";
+import { ProFooter3 } from "@/components/problocks/footer-3";
 
 const navItems = [
   { href: "/", label: "Home" },
@@ -11,7 +11,7 @@ const navItems = [
   { href: "/contribute", label: "Contribute" },
 ];
 
-export function Header() {
-  return <ProNavbar items={navItems} className="justify-center" />;
+export function Footer() {
+  return <ProFooter3 items={navItems} />;
 }
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,6 @@
 // Main Components Export
 export * from "./ui";
 export * from "./header";
+export * from "./footer";
 export * from "./theme-provider";
 export * from "./theme-toggle";

--- a/src/components/problocks/footer-3.tsx
+++ b/src/components/problocks/footer-3.tsx
@@ -1,0 +1,1 @@
+export { Footer3 as ProFooter3 } from "@everydaymoney/pro-blocks";

--- a/src/components/problocks/navbar.tsx
+++ b/src/components/problocks/navbar.tsx
@@ -1,0 +1,1 @@
+export { Navbar1 as ProNavbar } from "@everydaymoney/pro-blocks";

--- a/src/components/problocks/rich-text-section-1.tsx
+++ b/src/components/problocks/rich-text-section-1.tsx
@@ -1,0 +1,1 @@
+export { RichTextSection1 as ProRichText1 } from "@everydaymoney/pro-blocks";

--- a/src/components/problocks/rich-text-section-4.tsx
+++ b/src/components/problocks/rich-text-section-4.tsx
@@ -1,0 +1,1 @@
+export { RichTextSection4 as ProRichText4 } from "@everydaymoney/pro-blocks";


### PR DESCRIPTION
## Summary
- replace custom header with Pro Blocks navbar using wrapper
- add Manifesto and Medium of Exchange pages with Pro Blocks rich text sections
- introduce sitewide footer with Pro Blocks and matching nav links

## Testing
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_68c5f1b0cbc08327a1a18e64a1e2297a