### PR TITLE
feat: add live on bitcoin map and guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Live on Bitcoin
+
+Visit `/live` to explore an interactive world map of countries living on Bitcoin. Select a highlighted country to open its guide.

--- a/content/countries/CR.mdx
+++ b/content/countries/CR.mdx
@@ -1,0 +1,7 @@
+---
+title: "Costa Rica Guide"
+countryCode: "CR"
+updated: "2025-01-01"
+---
+
+This is a placeholder guide for Costa Rica.

--- a/content/countries/DE.mdx
+++ b/content/countries/DE.mdx
@@ -1,0 +1,7 @@
+---
+title: "Germany Guide"
+countryCode: "DE"
+updated: "2025-01-01"
+---
+
+This is a placeholder guide for Germany.

--- a/content/countries/PL.mdx
+++ b/content/countries/PL.mdx
@@ -1,0 +1,7 @@
+---
+title: "Poland Guide"
+countryCode: "PL"
+updated: "2025-01-01"
+---
+
+This is a placeholder guide for Poland.

--- a/content/countries/SV.mdx
+++ b/content/countries/SV.mdx
@@ -1,0 +1,7 @@
+---
+title: "El Salvador Guide"
+countryCode: "SV"
+updated: "2025-01-01"
+---
+
+This is a placeholder guide for El Salvador.

--- a/content/countries/US.mdx
+++ b/content/countries/US.mdx
@@ -1,0 +1,7 @@
+---
+title: "United States Guide"
+countryCode: "US"
+updated: "2025-01-01"
+---
+
+This is a placeholder guide for the United States.

--- a/src/app/live/[country]/page.tsx
+++ b/src/app/live/[country]/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+import fs from "fs";
+import path from "path";
+import { compileMDX } from "next-mdx-remote/rsc";
+import { ISO2_TO_NAME } from "@/lib/iso";
+
+export async function generateMetadata({ params }: { params: Promise<{ country: string }> }): Promise<Metadata> {
+  const { country } = await params;
+  const code = country.toUpperCase();
+  const name = ISO2_TO_NAME[code] ?? code;
+  return {
+    title: `Live on Bitcoin — ${name}`,
+  };
+}
+
+export default async function CountryPage({ params }: { params: Promise<{ country: string }> }) {
+  const { country } = await params;
+  const code = country.toUpperCase();
+  const name = ISO2_TO_NAME[code] ?? code;
+  const filePath = path.join(process.cwd(), "content", "countries", `${code}.mdx`);
+
+  if (fs.existsSync(filePath)) {
+    const source = fs.readFileSync(filePath, "utf8");
+    const { content } = await compileMDX({
+      source,
+      options: { parseFrontmatter: true },
+    });
+
+    return (
+      <div className="container mx-auto py-8">
+        <h1 className="mb-4 text-3xl font-bold">Live on Bitcoin — {name}</h1>
+        <article className="prose dark:prose-invert">{content}</article>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto py-8">
+      <h1 className="mb-4 text-3xl font-bold">Live on Bitcoin — {name}</h1>
+      <p>Guide coming soon</p>
+    </div>
+  );
+}

--- a/src/app/live/page.tsx
+++ b/src/app/live/page.tsx
@@ -1,107 +1,34 @@
-"use client";
-
-import { useState, useMemo } from "react";
-
-// Sample country data - in a real app, this would come from your content/countries directory
-const countries = [
-  { code: "PL", name: "Poland", slug: "poland" },
-  { code: "US", name: "United States", slug: "united-states" },
-  { code: "DE", name: "Germany", slug: "germany" },
-  { code: "SV", name: "El Salvador", slug: "el-salvador" },
-  { code: "CR", name: "Central African Republic", slug: "central-african-republic" },
-  { code: "AR", name: "Argentina", slug: "argentina" },
-  { code: "BR", name: "Brazil", slug: "brazil" },
-  { code: "CA", name: "Canada", slug: "canada" },
-  { code: "FR", name: "France", slug: "france" },
-  { code: "IT", name: "Italy", slug: "italy" },
-  { code: "JP", name: "Japan", slug: "japan" },
-  { code: "MX", name: "Mexico", slug: "mexico" },
-  { code: "NL", name: "Netherlands", slug: "netherlands" },
-  { code: "ES", name: "Spain", slug: "spain" },
-  { code: "GB", name: "United Kingdom", slug: "united-kingdom" },
-];
+import Link from "next/link";
+import WorldMap from "@/components/map/WorldMap";
+import { getCountryCodes } from "@/lib/content";
+import { ISO2_TO_NAME } from "@/lib/iso";
 
 export default function LivePage() {
-  const [searchTerm, setSearchTerm] = useState("");
-
-  const filteredCountries = useMemo(() => {
-    if (!searchTerm.trim()) {
-      return countries;
-    }
-    
-    return countries.filter(country =>
-      country.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      country.code.toLowerCase().includes(searchTerm.toLowerCase())
-    );
-  }, [searchTerm]);
+  const codes = getCountryCodes();
 
   return (
-    <div className="min-h-[calc(100vh-3.5rem)] bg-background text-foreground">
-      <div className="container mx-auto px-4 py-8 max-w-4xl">
-        <header className="mb-8">
-          <h1 className="text-3xl font-bold mb-2">Live on Bitcoin</h1>
-          <p className="text-muted-foreground">
-            Explore countries where Bitcoin is legal tender or widely adopted.
-          </p>
-        </header>
-
-        <div className="mb-8">
-          <label 
-            htmlFor="country-search" 
-            className="block text-sm font-medium mb-2"
-          >
-            Search countries
-          </label>
-          <input
-            id="country-search"
-            type="text"
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            placeholder="Type to search countries..."
-            className="w-full px-3 py-2 border border-border rounded-md bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent transition-colors"
-            aria-describedby="search-help"
-          />
-          <p id="search-help" className="text-xs text-muted-foreground mt-1">
-            Search by country name or country code
-          </p>
-        </div>
-
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {filteredCountries.length > 0 ? (
-            filteredCountries.map((country) => (
-              <a
-                key={country.code}
-                href={`/live/${country.slug}`}
-                className="block p-4 border border-border rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-                aria-label={`View Bitcoin adoption in ${country.name}`}
-              >
-                <div className="flex items-center gap-3">
-                  <span className="text-2xl font-mono text-muted-foreground">
-                    {country.code}
-                  </span>
-                  <div>
-                    <h3 className="font-medium">{country.name}</h3>
-                    <p className="text-sm text-muted-foreground">
-                      View details →
-                    </p>
-                  </div>
-                </div>
-              </a>
-            ))
+    <div className="container mx-auto py-8">
+      <h1 className="mb-8 text-3xl font-bold">Live on Bitcoin</h1>
+      <div className="grid gap-8 md:grid-cols-2">
+        <WorldMap />
+        <div>
+          {codes.length > 0 ? (
+            <ul className="space-y-2">
+              {codes.map((code) => (
+                <li key={code}>
+                  <Link
+                    href={`/live/${code.toLowerCase()}`}
+                    className="text-blue-600 hover:underline"
+                  >
+                    {ISO2_TO_NAME[code] ?? code}
+                  </Link>
+                </li>
+              ))}
+            </ul>
           ) : (
-            <div className="col-span-full text-center py-8">
-              <p className="text-muted-foreground">
-                No countries found matching &ldquo;{searchTerm}&rdquo;
-              </p>
-            </div>
+            <p className="text-muted-foreground">Guides coming soon.</p>
           )}
         </div>
-
-        {filteredCountries.length > 0 && (
-          <div className="mt-8 text-center text-sm text-muted-foreground">
-            Showing {filteredCountries.length} of {countries.length} countries
-          </div>
-        )}
       </div>
     </div>
   );

--- a/src/app/medium-of-exchange/page.tsx
+++ b/src/app/medium-of-exchange/page.tsx
@@ -1,10 +1,5 @@
 import { RichTextSection4 } from "@/components/pro-blocks/landing-page/rich-text-sections/rich-text-section-4";
 
 export default function MediumOfExchangePage() {
-  return (
-    <RichTextSection4
-      title="Medium of Exchange"
-      content="## Placeholder\n\nDetails coming soon."
-    />
-  );
+  return <RichTextSection4 />;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,5 @@
 import { RichTextSection1 } from "@/components/pro-blocks/landing-page/rich-text-sections/rich-text-section-1";
 
 export default function Home() {
-  return (
-    <RichTextSection1
-      title="Manifesto"
-      content="## Placeholder\n\nContent coming soon."
-    />
-  );
+  return <RichTextSection1 />;
 }

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -2,16 +2,7 @@
 
 import { Footer3 } from "@/components/pro-blocks/landing-page/footers/footer-3";
 
-const navItems = [
-  { href: "/", label: "Home" },
-  { href: "/", label: "Manifesto" },
-  { href: "/medium-of-exchange", label: "Medium of Exchange" },
-  { href: "/live", label: "Live on Bitcoin" },
-  { href: "/blog", label: "Blog" },
-  { href: "/contribute", label: "Contribute" },
-];
-
 export function Footer() {
-  return <Footer3 items={navItems} />;
+  return <Footer3 />;
 }
 

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -2,16 +2,7 @@
 
 import { Navbar1 } from "@/components/pro-blocks/application/navbars/navbar-1";
 
-const navItems = [
-  { href: "/", label: "Home" },
-  { href: "/", label: "Manifesto" },
-  { href: "/medium-of-exchange", label: "Medium of Exchange" },
-  { href: "/live", label: "Live on Bitcoin" },
-  { href: "/blog", label: "Blog" },
-  { href: "/contribute", label: "Contribute" },
-];
-
 export function Header() {
-  return <Navbar1 items={navItems} className="justify-center" />;
+  return <Navbar1 />;
 }
 

--- a/src/components/map/WorldMap.tsx
+++ b/src/components/map/WorldMap.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { ComposableMap, Geographies, Geography } from "react-simple-maps";
+import { useRouter } from "next/navigation";
+import { NAME_TO_ISO2 } from "@/lib/iso";
+
+const geoUrl = "/maps/world-110m.json";
+
+export function WorldMap() {
+  const router = useRouter();
+
+  type GeoFeature = { rsmKey: string; properties: { name: string } };
+  const handleSelect = (geo: GeoFeature) => {
+    const iso2 = NAME_TO_ISO2[geo.properties.name];
+    if (iso2) {
+      router.push(`/live/${iso2.toLowerCase()}`);
+    }
+  };
+
+  return (
+    <ComposableMap aria-label="World map">
+      <Geographies geography={geoUrl}>
+        {({ geographies }: { geographies: unknown[] }) =>
+          (geographies as GeoFeature[]).map((geo) => (
+            <Geography
+              key={geo.rsmKey}
+              geography={geo}
+              tabIndex={0}
+              aria-label={geo.properties.name}
+              onClick={() => handleSelect(geo)}
+              onKeyDown={(e: React.KeyboardEvent<SVGPathElement>) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  handleSelect(geo);
+                }
+              }}
+              style={{
+                default: {
+                  fill: "#E5E7EB",
+                  stroke: "#9CA3AF",
+                  outline: "none",
+                },
+                hover: {
+                  fill: "#D1D5DB",
+                  stroke: "#6B7280",
+                  cursor: "pointer",
+                },
+                pressed: {
+                  fill: "#9CA3AF",
+                  stroke: "#6B7280",
+                  outline: "none",
+                },
+              }}
+            />
+          ))
+        }
+      </Geographies>
+    </ComposableMap>
+  );
+}
+
+export default WorldMap;

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -1,0 +1,13 @@
+import fs from "fs";
+import path from "path";
+
+export function getCountryCodes(): string[] {
+  const dir = path.join(process.cwd(), "content", "countries");
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+  return fs
+    .readdirSync(dir)
+    .filter((file) => file.endsWith(".mdx"))
+    .map((file) => file.replace(/\.mdx$/, ""));
+}

--- a/src/lib/iso.ts
+++ b/src/lib/iso.ts
@@ -1,0 +1,11 @@
+export const ISO2_TO_NAME: Record<string, string> = {
+  PL: "Poland",
+  US: "United States of America",
+  DE: "Germany",
+  SV: "El Salvador",
+  CR: "Costa Rica",
+};
+
+export const NAME_TO_ISO2: Record<string, string> = Object.fromEntries(
+  Object.entries(ISO2_TO_NAME).map(([code, name]) => [name, code])
+);

--- a/types/react-simple-maps.d.ts
+++ b/types/react-simple-maps.d.ts
@@ -1,0 +1,1 @@
+declare module "react-simple-maps";


### PR DESCRIPTION
## Summary
- add ISO mappings and helper to discover country guides
- render interactive world map with accessible navigation
- implement live country pages that load MDX content or fall back
- remove unsupported props from pro-block wrappers and declare map types to fix build
- document Live on Bitcoin map in README

## Testing
- `pnpm lint`
- `pnpm build`

## Manual Testing
- Start dev server: `pnpm dev`
- Visit `http://localhost:3000/live`
- Click on Poland; confirm navigation to `/live/pl` and placeholder guide renders

------
https://chatgpt.com/codex/tasks/task_e_68c5fb8a6de08327b5038671dbae4aeb